### PR TITLE
Remove legacy dependencies from modern .NET targets

### DIFF
--- a/src/GenerativeAI/GenerativeAI.csproj
+++ b/src/GenerativeAI/GenerativeAI.csproj
@@ -28,12 +28,6 @@
     </None>
   </ItemGroup>
 
-   
-    <ItemGroup>
-        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
-        <PackageReference Include="System.Net.Http" Version="4.3.4"/>
-    </ItemGroup>
-
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="JsonSchema.Net.Generation" Version="5.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1"/>
@@ -54,10 +48,12 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1"/>
         <PackageReference Include="System.Text.Json" Version="8.0.5"/>
     </ItemGroup>
-     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
          <PackageReference Include="JsonSchema.Net.Generation" Version="3.5.1"/>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1"/>
         <PackageReference Include="System.Text.Json" Version="8.0.5"/>
+        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
+        <PackageReference Include="System.Net.Http" Version="4.3.4"/>
     </ItemGroup>
     <!-- <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
         <PackageReference Include="JsonSchema.Net.Generation" Version="2.2.1"/>
@@ -69,6 +65,8 @@
         <PackageReference Include="JsonSchema.Net.Generation" Version="5.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1"/>
         <PackageReference Include="System.Text.Json" Version="9.0.1"/>
+        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
+        <PackageReference Include="System.Net.Http" Version="4.3.4"/>
     </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There's more that could be done in this direction, but it should probably be done a bit careful to avoid breaking stuff and I don't know the codebase and where it uses `#if` etc well enough. My priority with this was to greatly reduce the dependency tree for consumers on modern .NET. `System.Net.Http` and `System.ComponentModel.Annotations` are available out of the box today. [System.Net.Http](https://www.nuget.org/packages/System.Net.Http) is problematic because it is from before the `netstandard2.0` days, which simplified the dependency tree. Having it as a transitive dependency thus introduces a lot of legacy clutter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Optimized dependency management to ensure consistent performance and compatibility across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->