### PR TITLE
Add logging for invalid WebSocket payloads and new properties

### DIFF
--- a/src/GenerativeAI.Live/Logging/LoggingExtensions.cs
+++ b/src/GenerativeAI.Live/Logging/LoggingExtensions.cs
@@ -47,4 +47,7 @@ public static partial class MultiModalLiveClientLoggingExtensions
 
     [LoggerMessage(EventId = 112, Level = LogLevel.Information, Message = "Calling function: {FunctionName}")]
     public static partial void LogFunctionCall(this ILogger logger, string functionName);
+
+    [LoggerMessage(EventId = 113, Level = LogLevel.Error, Message = "WebSocket connection closed caused by invalid payload: {CloseStatusDescription}")]
+    public static partial void LogConnectionClosedWithInvalidPyload(this ILogger logger, string closeStatusDescription);
 }

--- a/src/GenerativeAI.Live/Models/MultiModalLiveClient.cs
+++ b/src/GenerativeAI.Live/Models/MultiModalLiveClient.cs
@@ -429,6 +429,11 @@ public class MultiModalLiveClient : IDisposable
                 _logger?.LogConnectionClosedWithError(info.Type, info.Exception!);
                 ErrorOccurred?.Invoke(this, new ErrorEventArgs(info.Exception!)); 
             }
+            else if (info.CloseStatus == WebSocketCloseStatus.InvalidPayloadData)
+            {
+                //log info.CloseStatusDescription
+                _logger?.LogConnectionClosedWithInvalidPyload(info.CloseStatusDescription!);
+            }
             else
             {
                 _logger?.LogConnectionClosed();

--- a/src/GenerativeAI/Types/MultimodalLive/BidiGenerateContentSetup.cs
+++ b/src/GenerativeAI/Types/MultimodalLive/BidiGenerateContentSetup.cs
@@ -43,4 +43,14 @@ public class BidiGenerateContentSetup
     /// </summary>
     [JsonPropertyName("tools")]
     public Tool[]? Tools { get; set; }
+
+    [JsonPropertyName("outputAudioTranscription")]
+    public OutputAudioTranscription? OutputAudioTranscription { get; set; } = new OutputAudioTranscription();
+
+    [JsonPropertyName("inputAudioTranscription")]
+    public OutputAudioTranscription? InputAudioTranscription { get; set; }
+}
+public class OutputAudioTranscription
+{
+
 }


### PR DESCRIPTION
- Introduced `LogConnectionClosedWithInvalidPyload` method in `MultiModalLiveClientLoggingExtensions` to log errors for WebSocket closures due to invalid payloads.
- Updated `MultiModalLiveClient` to log close status descriptions for invalid payloads.
- Added `OutputAudioTranscription` and `InputAudioTranscription` properties to `BidiGenerateContentSetup`, initialized with new instances.
- Created a new class `OutputAudioTranscription` for handling audio transcription data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options for handling input and output audio transcription in content generation setup.
- **Bug Fixes**
  - Improved error logging for WebSocket connections closed due to invalid payloads, providing more detailed information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->