### PR TITLE
Added error message propagation to client.

### DIFF
--- a/src/GenerativeAI.Live/Events/ErrorMessageEventArgs.cs
+++ b/src/GenerativeAI.Live/Events/ErrorMessageEventArgs.cs
@@ -1,0 +1,20 @@
+﻿namespace GenerativeAI.Live.Events;
+
+/// <summary>
+/// Provides error message event data.
+/// </summary>
+public class ErrorMessageEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the payload of the received message.
+    /// </summary>
+    public string ErrorMessage { get; }
+
+    /// <devdoc>
+    ///    Initializes a new instance of the class.
+    /// </devdoc>
+    public ErrorMessageEventArgs(string errorMessage)
+    {
+        ErrorMessage = errorMessage;
+    }
+}

--- a/src/GenerativeAI.Live/Models/MultiModalLiveClient.cs
+++ b/src/GenerativeAI.Live/Models/MultiModalLiveClient.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using GenerativeAI.Core;
+using GenerativeAI.Live.Events;
 using GenerativeAI.Live.Helper;
 using GenerativeAI.Live.Logging;
 using GenerativeAI.Types;
@@ -559,6 +560,11 @@ public class MultiModalLiveClient : IDisposable
             {
                 //log info.CloseStatusDescription
                 _logger?.LogConnectionClosedWithInvalidPyload(info.CloseStatusDescription!);
+            }
+            else if (info.CloseStatus == WebSocketCloseStatus.InternalServerError && !string.IsNullOrEmpty(info.CloseStatusDescription))
+            {
+                _logger?.LogConnectionClosedWithError(info.Type, info.Exception!);
+                Disconnected?.Invoke(this, new ErrorMessageEventArgs(info.CloseStatusDescription));
             }
             else
             {


### PR DESCRIPTION
Added that message on server error is propagated back to client.
In case of quote extension, Gemini Live returns Internal Server Error with message:
`You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: h`.
In such case SDK disconnected client without any info why.