### PR TITLE
Added languageCode and multiSpeakerVoiceConfig properties to SpeechConfig

### DIFF
--- a/src/GenerativeAI/Types/ContentGeneration/Config/MultiSpeakerVoiceConfig.cs
+++ b/src/GenerativeAI/Types/ContentGeneration/Config/MultiSpeakerVoiceConfig.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace GenerativeAI.Types;
+
+/// <summary>
+/// The configuration for the multi-speaker setup.
+/// </summary>
+/// <seealso href="https://ai.google.dev/api/generate-content#MultiSpeakerVoiceConfig">See Official API Documentation</seealso>
+public class MultiSpeakerVoiceConfig
+{
+    /// <summary>
+    /// Required. All the enabled speaker voices.
+    /// </summary>
+    [JsonPropertyName("speakerVoiceConfigs")]
+    public List<SpeakerVoiceConfig>? SpeakerVoiceConfigs { get; set; }
+}

--- a/src/GenerativeAI/Types/ContentGeneration/Config/SpeakerVoiceConfig.cs
+++ b/src/GenerativeAI/Types/ContentGeneration/Config/SpeakerVoiceConfig.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace GenerativeAI.Types;
+
+/// <summary>
+/// The configuration for a single speaker in a multi speaker setup.
+/// </summary>
+/// <seealso href="https://ai.google.dev/api/generate-content#SpeakerVoiceConfig">See Official API Documentation</seealso>
+public class SpeakerVoiceConfig
+{
+    /// <summary>
+    /// Required. The name of the speaker to use. Should be the same as in the prompt.
+    /// </summary>
+    [JsonPropertyName("speaker")]
+    public string? Speaker { get; set; }
+
+    /// <summary>
+    /// Required. The configuration for the voice to use.
+    /// </summary>
+    [JsonPropertyName("voiceConfig")]
+    public VoiceConfig? VoiceConfig { get; set; }
+}

--- a/src/GenerativeAI/Types/ContentGeneration/Config/SpeechConfig.cs
+++ b/src/GenerativeAI/Types/ContentGeneration/Config/SpeechConfig.cs
@@ -13,4 +13,18 @@ public class SpeechConfig
     /// </summary>
     [JsonPropertyName("voiceConfig")]
     public VoiceConfig? VoiceConfig { get; set; }
+
+    /// <summary>
+    /// Optional. The configuration for the multi-speaker setup.
+    /// It is mutually exclusive with the <see cref="VoiceConfig"/> field.
+    /// </summary>
+    [JsonPropertyName("multiSpeakerVoiceConfig")]
+    public MultiSpeakerVoiceConfig? MultiSpeakerVoiceConfig { get; set; }
+
+    /// <summary>
+    /// Optional. Language code (in BCP 47 format, e.g. "en-US") for speech synthesis.
+    /// Valid values are shown at the above URI.
+    /// </summary>
+    [JsonPropertyName("languageCode")]
+    public string? LanguageCode { get; set; }
 }


### PR DESCRIPTION
Adds two missing properties to the SpeechConfig class, including the new model classes that make up the multi-speaker config tree.  Comments and JSON property names mirror the Google docs.  This is meant to close #77.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-speaker voice configuration capabilities for audio generation
  * Added language code support for speech synthesis with BCP 47 language specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->