### PR TITLE
Refactored DisconnectionHappened handler to always report errors

### DIFF
--- a/src/GenerativeAI.Live/Logging/LoggingExtensions.cs
+++ b/src/GenerativeAI.Live/Logging/LoggingExtensions.cs
@@ -123,10 +123,11 @@ public static partial class MultiModalLiveClientLoggingExtensions
     public static partial void LogFunctionCall(this ILogger logger, string functionName);
 
     /// <summary>
-    /// Logs an error message indicating that the WebSocket connection was closed due to an invalid payload.
+    /// Logs an error message indicating that the WebSocket connection was closed with a status code and description.
     /// </summary>
     /// <param name="logger">The logger to log the message to.</param>
+    /// <param name="closeStatus">Indicates the reason why the remote endpoint initiated the close handshake.</param>
     /// <param name="closeStatusDescription">The description of the close status that caused the connection to close.</param>
-    [LoggerMessage(EventId = 113, Level = LogLevel.Error, Message = "WebSocket connection closed caused by invalid payload: {CloseStatusDescription}")]
-    public static partial void LogConnectionClosedWithInvalidPyload(this ILogger logger, string closeStatusDescription);
+    [LoggerMessage(EventId = 114, Level = LogLevel.Error, Message = "WebSocket connection closed with status {CloseStatus}: {CloseStatusDescription}")]
+    public static partial void LogConnectionClosedWithStatus(this ILogger logger, WebSocketCloseStatus? closeStatus, string closeStatusDescription);
 }


### PR DESCRIPTION
This change tries to make the disconnection handler a little more forgiving of different input combinations.  It addresses #81.  Changes are:

1. I removed the "invalid payload" error handler -- I don't think we want to be in the business of making explicit handlers for every status type/error condition.  Easier to just report the property values and let the user interpret them.
2. The close status/description is always reported if it is present.
3. The exception is always handled if it is present.  (And the ErrorOccurred handler is invoked in this case.)
4. The `Disconnected` handler is _always_ called -- it only depends what its arguments are.  Personally I would recommend refactoring this to simply pass `info` out to the client so you can provide a strongly-typed EventArgs, but I didn't want to break compatibility and this gets the job done.  (Also, the user can always add her own DisconnectionHappened handler if you decide to merge #80.)

With this patch you still get the following in the normal case:

> MultiModalLiveClient: WebSocket connection closed normally.

But when a non-normal status comes in, you get something like this:

> MultiModalLiveClient: WebSocket connection closed with status "PolicyViolation": API keys are not supported by this API.

Very helpful, I think!

(PS. This is my last bug/PR for now.  Thanks a lot for your attention, and for the great library! 🫶 )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages and logging when WebSocket connections disconnect, providing clearer status information about the reason for disconnection.
  * Enhanced error reporting during connection failures to better distinguish between different closure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->