### PR TITLE
Correct Vertex global region endpoint URL construction

### DIFF
--- a/src/GenerativeAI/Platforms/VertextPlatformAdapter.cs
+++ b/src/GenerativeAI/Platforms/VertextPlatformAdapter.cs
@@ -342,7 +342,7 @@ public class VertextPlatformAdapter : IPlatformAdapter
         }
 
         // Start with base domain
-        string baseUrl = $"https://{Region}-aiplatform.googleapis.com";
+        var baseUrl = Region == "global" ? "https://aiplatform.googleapis.com" : $"https://{Region}-aiplatform.googleapis.com";
       
         // Append version: /{version}
         if (appendVersion)


### PR DESCRIPTION
Updated VertextPlatformAdapter.GetBaseUrl() to handle the global region as a special case without the region prefix. 

Fixes #71 

Tested with and without Microsoft.Extensions.AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Vertex AI platform connectivity for the global region by correcting the endpoint URL configuration to properly resolve global region deployments while maintaining compatibility with regional endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->