### PR TITLE
fix: support Dimensions parameter in GenerativeAI.Microsoft

### DIFF
--- a/src/GenerativeAI.Microsoft/GenerativeAIEmbeddingGenerator.cs
+++ b/src/GenerativeAI.Microsoft/GenerativeAIEmbeddingGenerator.cs
@@ -77,7 +77,8 @@ public sealed class GenerativeAIEmbeddingGenerator : IEmbeddingGenerator<string,
                     Parts = [new Part { Text = text }]
                 },
                 Model = Model.Model,
-                TaskType = GetTaskType(options)
+                TaskType = GetTaskType(options),
+                OutputDimensionality = options?.Dimensions
             });
 
             // Call the batch embed API


### PR DESCRIPTION
### Description
This PR fixes a bug where the `Dimensions` property in `EmbeddingGenerationOptions` was ignored when generating embeddings.

Previously, setting `Dimensions` had no effect, and the API would return the full-length vector (e.g., 3072 for `gemini-embedding-001`). This change ensures the dimension parameter is correctly passed to the Gemini API.

### Related Issue
Closes #95 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
I verified the fix using the code snippet that originally reproduced the issue.

**Test Code:**
```csharp
var options = new EmbeddingGenerationOptions() { Dimensions = 1536 };
var generator = new GenerativeAIEmbeddingGenerator(key, "models/gemini-embedding-001");
var embedding = (await generator.GenerateAsync(["test"], options))[0].Vector;
Console.WriteLine(embedding.Length);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedding generation now supports configurable output dimensionality settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->