### PR TITLE
Switch `Console.WriteLine` over to `Debug.WriteLine` so as not to use Console.Out as debug log

### DIFF
--- a/src/GenerativeAI.Microsoft/GenerativeAIChatClient.cs
+++ b/src/GenerativeAI.Microsoft/GenerativeAIChatClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using GenerativeAI.Core;
@@ -218,7 +219,7 @@ public sealed class GenerativeAIChatClient : IChatClient
         // before request construction; otherwise inline_data blows past
         // Gemini's per-part limit and the call rejects.
         var messageList = messages as IList<ChatMessage> ?? messages.ToList();
-        Console.WriteLine($"[GenerativeAIChatClient] STREAM start — model={model.Model}, messages={messageList.Count}");
+        Debug.WriteLine($"[GenerativeAIChatClient] STREAM start — model={model.Model}, messages={messageList.Count}");
         for (int mi = 0; mi < messageList.Count; mi++)
         {
             var m = messageList[mi];
@@ -227,15 +228,15 @@ public sealed class GenerativeAIChatClient : IChatClient
                 var c = m.Contents[ci];
                 if (c is DataContent dc)
                 {
-                    Console.WriteLine($"[GenerativeAIChatClient]   msg[{mi}].content[{ci}] = DataContent mime={dc.MediaType} bytes={dc.Data.Length}");
+                    Debug.WriteLine($"[GenerativeAIChatClient]   msg[{mi}].content[{ci}] = DataContent mime={dc.MediaType} bytes={dc.Data.Length}");
                 }
                 else if (c is TextContent tc)
                 {
-                    Console.WriteLine($"[GenerativeAIChatClient]   msg[{mi}].content[{ci}] = TextContent {tc.Text?.Length ?? 0} chars");
+                    Debug.WriteLine($"[GenerativeAIChatClient]   msg[{mi}].content[{ci}] = TextContent {tc.Text?.Length ?? 0} chars");
                 }
                 else
                 {
-                    Console.WriteLine($"[GenerativeAIChatClient]   msg[{mi}].content[{ci}] = {c.GetType().Name}");
+                    Debug.WriteLine($"[GenerativeAIChatClient]   msg[{mi}].content[{ci}] = {c.GetType().Name}");
                 }
             }
         }
@@ -265,7 +266,7 @@ public sealed class GenerativeAIChatClient : IChatClient
                         if (p.FunctionResponse != null) return $"fnResp({p.FunctionResponse.Name})";
                         return "?";
                     }));
-                Console.WriteLine($"[GenerativeAIChatClient]   request.Contents[{ci}] role={content.Role} parts=[{partsDesc}]");
+                Debug.WriteLine($"[GenerativeAIChatClient]   request.Contents[{ci}] role={content.Role} parts=[{partsDesc}]");
             }
         }
         GenerateContentResponse? lastResponse = null;


### PR DESCRIPTION
The original code is using `Console.Out` for debug messages. I didn't want to outright strip them away, but they are noise in terms of using this library, especially if you're trying to write a CLI tool, like I am.

If the library requires a `TextWriter` to write debug messages to, either a different one should be used, or an optional override property should be provided so that users of the package can opt-out of this debug log.

Instead, I switched the offending lines to use `Debug.WriteLine`. If the lines have served their purpose, however, they should probably be removed instead.

I did not get to run all unit tests successfully, as it relied on locally installed npx, which I don't have, and I suspect the official list of models from Google has changed so that some of the tests that ensure models exists are also failing. I did not, however, find any tests related to using the offending debug log messages, so I assumed it was safe to make the switch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved diagnostic logging for streaming responses without displaying internal request and message details in standard application output.
  * Streaming activity and content information is now available through debug logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->